### PR TITLE
投稿ボタンタップ時に投稿と写真を保存する処理作成しました。

### DIFF
--- a/PetSNS.xcodeproj/project.pbxproj
+++ b/PetSNS.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		4EA5C3D526EB263300626ADE /* ThemeColorCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5C3D326EB263300626ADE /* ThemeColorCollectionViewCell.swift */; };
 		4EA5C3D626EB263300626ADE /* ThemeColorCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4EA5C3D426EB263300626ADE /* ThemeColorCollectionViewCell.xib */; };
 		4EA5C3D826F242D600626ADE /* Owner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EA5C3D726F242D600626ADE /* Owner.swift */; };
+		75395AF727102D0E00492D69 /* PostUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75395AF627102D0E00492D69 /* PostUtil.swift */; };
 		755E9AC626D7931C00A17709 /* HomeContainerPosts.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 755E9AC526D7931C00A17709 /* HomeContainerPosts.storyboard */; };
 		755E9AC826D7933C00A17709 /* HomeContainerPostsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755E9AC726D7933C00A17709 /* HomeContainerPostsViewController.swift */; };
 		755E9B1E26DB4F9F00A17709 /* SwitchingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 755E9B1C26DB4F9F00A17709 /* SwitchingTableViewCell.swift */; };
@@ -85,6 +86,7 @@
 		4EA5C3D326EB263300626ADE /* ThemeColorCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorCollectionViewCell.swift; sourceTree = "<group>"; };
 		4EA5C3D426EB263300626ADE /* ThemeColorCollectionViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ThemeColorCollectionViewCell.xib; sourceTree = "<group>"; };
 		4EA5C3D726F242D600626ADE /* Owner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Owner.swift; sourceTree = "<group>"; };
+		75395AF627102D0E00492D69 /* PostUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostUtil.swift; sourceTree = "<group>"; };
 		755E9AC526D7931C00A17709 /* HomeContainerPosts.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = HomeContainerPosts.storyboard; sourceTree = "<group>"; };
 		755E9AC726D7933C00A17709 /* HomeContainerPostsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeContainerPostsViewController.swift; sourceTree = "<group>"; };
 		755E9B1C26DB4F9F00A17709 /* SwitchingTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwitchingTableViewCell.swift; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 			children = (
 				4EA5C3DB26F2439B00626ADE /* User */,
 				AB14B47A26DBDAEB007A5F16 /* UserUtil.swift */,
+				75395AF627102D0E00492D69 /* PostUtil.swift */,
 				AB4397F626DDEA56008C8CA8 /* Indicator.swift */,
 				AB4397F826DDF46B008C8CA8 /* HUDIndicator.swift */,
 				4EA5C3CF26E20C6800626ADE /* LocalValidationChecker.swift */,
@@ -606,6 +609,7 @@
 				AB14B47926DBC59D007A5F16 /* NotificationName+Extension.swift in Sources */,
 				AB86A7E926D3D76800EA990A /* SceneDelegate.swift in Sources */,
 				AB14B47B26DBDAEB007A5F16 /* UserUtil.swift in Sources */,
+				75395AF727102D0E00492D69 /* PostUtil.swift in Sources */,
 				4EA5C3D826F242D600626ADE /* Owner.swift in Sources */,
 				AB14B47726DBC08A007A5F16 /* TopTabBarController.swift in Sources */,
 				AB86A84D26D3E39400EA990A /* SettingViewController.swift in Sources */,

--- a/PetSNS/Controllers/Camera/EditingPostViewController.swift
+++ b/PetSNS/Controllers/Camera/EditingPostViewController.swift
@@ -61,6 +61,7 @@ final class EditingPostViewController: UIViewController {
                 isSavedData = true
             }
         }
+        
         dispatchGroup.notify(queue: .main) {
             switch (isSavedPost, isSavedData) {
             case (true, true):
@@ -77,6 +78,7 @@ final class EditingPostViewController: UIViewController {
                 }
             }
         }
+        
     }
     
     @IBAction private func cancelButtonDidTapped(_ sender: Any) {

--- a/PetSNS/Controllers/Camera/EditingPostViewController.swift
+++ b/PetSNS/Controllers/Camera/EditingPostViewController.swift
@@ -15,6 +15,7 @@ final class EditingPostViewController: UIViewController {
     @IBOutlet private weak var collectionView: UICollectionView!
     @IBOutlet private weak var commentTextView: UITextView!
     
+    private let indicator = Indicator(kinds: PKHUDIndicator())
     private var photoData: Data!
     func receivePhoto(photoData: Data) {
         self.photoData = photoData

--- a/PetSNS/Controllers/Camera/EditingPostViewController.swift
+++ b/PetSNS/Controllers/Camera/EditingPostViewController.swift
@@ -28,9 +28,21 @@ final class EditingPostViewController: UIViewController {
     }
     
     @IBAction private func postButtonDidTapped(_ sender: Any) {
-        NotificationCenter.default.post(name: .showHomeVC, object: nil)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-            self.dismiss(animated: true)
+        guard let text = commentTextView.text else { return }
+        let post = Post(id: UUID().uuidString,
+                        imageData: photoData,
+                        text: text)
+        PostUtil().save(post: post) { result in
+            switch result {
+            case .failure(let title):
+                self.showErrorAlert(title: title)
+            case .success:
+                NotificationCenter.default.post(name: .showHomeVC,
+                                                object: nil)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+                    self.dismiss(animated: true)
+                }
+            }
         }
     }
     

--- a/PetSNS/Models/PostUtil.swift
+++ b/PetSNS/Models/PostUtil.swift
@@ -6,3 +6,54 @@
 //
 
 import Foundation
+import Firebase
+
+final class PostUtil {
+    
+    let user = Auth.auth().currentUser
+    
+    func save(post: Post,
+              completion: @escaping ResultHandler<Any?>) {
+        guard let user = user else { return }
+        let storeRef = Firestore.firestore().collection("users/\(user.uid)/posts/")
+        let createdTime = FieldValue.serverTimestamp()
+        let postData: [String: Any] = ["id": post.id,
+                                       "text": post.text,
+                                       "createdAt": createdTime]
+        storeRef.addDocument(data: postData) { error in
+            if let error = error {
+                let message = self.firestoreErrorMessage(error)
+                completion(.failure(message))
+                return
+            }
+            completion(.success(nil))
+        }
+    }
+    
+    private func firestoreErrorMessage(_ error: Error) -> String {
+        if let errorCode = FirestoreErrorCode(rawValue: error._code) {
+            switch errorCode {
+            case .OK: return "操作は正常に完了しました。"
+            case .cancelled: return "操作がキャンセルされました。"
+            case .unknown: return "予期せぬエラーです。"
+            case .invalidArgument: return "システムの状態に関わらず、問題のある引数を示します。"
+            case .deadlineExceeded: return "時間内に操作が完了しませんでした。"
+            case .notFound: return "要求されたドキュメントが見つかりません。"
+            case .alreadyExists: return "既に存在しています。"
+            case .permissionDenied: return "操作権限がありません。"
+            case .resourceExhausted: return "容量が不足しています。"
+            case .failedPrecondition: return "操作が拒否されました。"
+            case .aborted: return "操作が中断されました。"
+            case .outOfRange: return "無効な操作です。"
+            case .unimplemented: return "この操作はサポートされていません。"
+            case .internal: return "システムエラーです。"
+            case .unavailable: return "現在このサービスは利用できません。"
+            case .dataLoss: return "回復不可能なデータ損失が発生しました。"
+            case .unauthenticated: return "有効な認証がありません。"
+            @unknown default:
+                return "未知のエラーです\(error)"
+            }
+        }
+        return "不明なエラーが発生しました。"
+    }
+}

--- a/PetSNS/Models/PostUtil.swift
+++ b/PetSNS/Models/PostUtil.swift
@@ -1,0 +1,8 @@
+//
+//  PostUtil.swift
+//  PetSNS
+//
+//  Created by 坂本龍哉 on 2021/10/08.
+//
+
+import Foundation

--- a/PetSNS/Models/user/Owner.swift
+++ b/PetSNS/Models/user/Owner.swift
@@ -35,7 +35,7 @@ struct Follower {
 struct Post {
     let id: String
     let imageData: Data
-    let text: String = ""
+    let text: String
     let likedUsers: [String] = []
     let comments: [Comment] = []
 }


### PR DESCRIPTION
#32
firestoreとstorageのどちらかの保存が失敗した場合は、成功した方のデータを削除する処理を書いて対応したらいいですか？
結局、削除処理も失敗はあるので根本的な解決にはなっていない気がしてしまい。。。
どちらも成功した場合だけ保存を完了させるみたいな方法調べたのですがわかりませんでした。
いい方法があれば教えて頂きたいです。